### PR TITLE
FIX: Always override svg-as-img height

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -3,7 +3,9 @@
 }
 
 img.svg-as-img {
-  height: 1em;
+  // !important needed here because we can't set height in img tag
+  // so we need to ensure core styling is always overriden
+  height: 1em !important;
   width: auto;
   padding-bottom: 0;
 }


### PR DESCRIPTION
@jjaffeux this is super minor, but I think we should do this instead of adding the class to core. 

Post-merge we can then revert https://github.com/discourse/discourse/commit/2f0205e5c850e40c278a0854c1cb121fdd175cbd. 